### PR TITLE
Override appstore service name

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -23,6 +23,14 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 {{- end }}
 
+{{- define "appstore-sockets.appstoreServiceName" -}}
+{{- if .Values.appstoreServiceNameOverride }}
+{{- .Values.appstoreServiceNameOverride }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name "appstore" }}
+{{- end }}
+{{- end }}
+
 {{/*
 Create chart name and version as used by the chart label.
 */}}

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -6,4 +6,4 @@ metadata:
 data:
   REQUIRE_PUBLISH_SECRET: "{{ .Values.requirePublishSecret }}"
   WS_HOST: "{{ .Values.serviceName }}"
-  APPSTORE_HOST: "{{ .Release.Name }}-appstore:8000"
+  APPSTORE_HOST: {{ include "appstore-sockets.appstoreServiceName" . }}:8000

--- a/values.yaml
+++ b/values.yaml
@@ -16,7 +16,7 @@ fullnameOverride: ""
 
 requirePublishSecret: true
 # If running outside helx-chart, you will need to override this value.
-appstoreServiceNameOverride: "foobar"
+appstoreServiceNameOverride: ""
 
 podAnnotations: {}
 

--- a/values.yaml
+++ b/values.yaml
@@ -15,6 +15,8 @@ nameOverride: ""
 fullnameOverride: ""
 
 requirePublishSecret: true
+# If running outside helx-chart, you will need to override this value.
+appstoreServiceNameOverride: "foobar"
 
 podAnnotations: {}
 


### PR DESCRIPTION
Adds value for overriding appstore service name (useful if deploying outside of helx-chart)