### PR TITLE
Change usage to podSecurityContext replacing securityContext

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -4,5 +4,5 @@ description: A Helm chart for Kubernetes
 
 type: application
 
-version: 1.0.1
+version: 2.0.0
 appVersion: 1.0.0

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -18,12 +18,8 @@ spec:
         {{- include "appstore-sockets.selectorLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "appstore-sockets.serviceAccountName" . }}
-      {{- if .Values.securityContext }}
       securityContext:
-        runAsUser: {{ .Values.securityContext.runAsUser }}
-        runAsGroup: {{ .Values.securityContext.runAsGroup }}
-        fsGroup: {{ .Values.securityContext.fsGroup }}
-      {{- end }}
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"

--- a/values.yaml
+++ b/values.yaml
@@ -19,16 +19,14 @@ requirePublishSecret: true
 appstoreServiceNameOverride: ""
 
 podAnnotations: {}
+podSecurityContext: {}
 
 serviceAccount:
   create: true
   annotations: {}
   name:
 
-securityContext:
-  runAsUser: 0
-  runAsGroup: 0
-  fsGroup: 0
+securityContext: {}
 
 serviceName: appstore-sockets-service
 service:


### PR DESCRIPTION
This chart was a cut-paste from the appstore chart, unfortunate as it inherited the **securityContext** vs. **podSecurityContext** issue while also setting default values for **fsGroup**, **runAsUser**, etc; deployment problems ensued.  This addresses those problems.